### PR TITLE
Add Assetage Struct For Vote or Other func 

### DIFF
--- a/contracts/eosio.system/CMakeLists.txt
+++ b/contracts/eosio.system/CMakeLists.txt
@@ -5,7 +5,7 @@ add_contract(eosio.system eosio.system
    ${CMAKE_CURRENT_SOURCE_DIR}/src/transfer.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/vote.cpp)
 
-target_include_directories(eosio.system PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(eosio.system PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 set_target_properties(eosio.system PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -7,11 +7,13 @@
 
 #include <string>
 
+#include <eosforce/assetage.hpp>
 #include <native.hpp>
 
 namespace eosio {
 
    using std::string;
+   using eosforce::assetage;
 
    static constexpr symbol CORE_SYMBOL    = symbol(symbol_code("EOS"), 4);
    static constexpr uint32_t FROZEN_DELAY = 3 * 24 * 60 * 20;               //3*24*60*20*3s;
@@ -46,6 +48,7 @@ namespace eosio {
             asset        staked                = asset{ 0, CORE_SYMBOL };
             uint32_t     voteage_update_height = 0;
             int64_t      voteage               = 0;           // asset.amount * block height
+            assetage     voteage_n;
             asset        unstaking             = asset{ 0, CORE_SYMBOL };
             uint32_t     unstake_height        = 0;
 

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -45,10 +45,7 @@ namespace eosio {
 
          struct [[eosio::table]] vote_info {
             account_name bpname                = 0;
-            asset        staked                = asset{ 0, CORE_SYMBOL };
-            uint32_t     voteage_update_height = 0;
-            int64_t      voteage               = 0;           // asset.amount * block height
-            assetage     voteage_n;
+            assetage     voteage;
             asset        unstaking             = asset{ 0, CORE_SYMBOL };
             uint32_t     unstake_height        = 0;
 

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -71,6 +71,25 @@ namespace eosio {
             std::string url;
             bool emergency = false;
 
+            // for bp_info, cannot change it table struct
+            inline void add_total_staked( const uint32_t curr_block_num, const asset& s ) {
+               total_voteage += total_staked * ( curr_block_num - voteage_update_height );
+               voteage_update_height = curr_block_num;
+               // JUST CORE_TOKEN can vote to bp
+               total_staked += s.amount / eosforce::utils::precision(CORE_SYMBOL.precision());
+            }
+
+            inline void add_total_staked( const uint32_t curr_block_num, const int64_t sa ) {
+               total_voteage += total_staked * ( curr_block_num - voteage_update_height );
+               voteage_update_height = curr_block_num;
+               // JUST CORE_TOKEN can vote to bp
+               total_staked += sa / eosforce::utils::precision(CORE_SYMBOL.precision());
+            }
+
+            inline constexpr int64_t get_age( const uint32_t curr_block_num ) const {
+               return (total_staked * ( curr_block_num - voteage_update_height )) + total_voteage;
+            }
+
             uint64_t primary_key() const { return name; }
          };
 

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -14,8 +14,8 @@ namespace eosio {
 
    using std::string;
    using eosforce::assetage;
+   using eosforce::CORE_SYMBOL;
 
-   static constexpr symbol CORE_SYMBOL    = symbol(symbol_code("EOS"), 4);
    static constexpr uint32_t FROZEN_DELAY = 3 * 24 * 60 * 20;               //3*24*60*20*3s;
    static constexpr int NUM_OF_TOP_BPS    = 23;
    static constexpr int BLOCK_REWARDS_BP  = 27000 ;                         //2.7000 EOS

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -13,8 +13,10 @@
 namespace eosio {
 
    using std::string;
+
    using eosforce::assetage;
    using eosforce::CORE_SYMBOL;
+   using eosforce::CORE_SYMBOL_PRECISION;
 
    static constexpr uint32_t FROZEN_DELAY = 3 * 24 * 60 * 20;               //3*24*60*20*3s;
    static constexpr int NUM_OF_TOP_BPS    = 23;
@@ -76,14 +78,14 @@ namespace eosio {
                total_voteage += total_staked * ( curr_block_num - voteage_update_height );
                voteage_update_height = curr_block_num;
                // JUST CORE_TOKEN can vote to bp
-               total_staked += s.amount / eosforce::utils::precision(CORE_SYMBOL.precision());
+               total_staked += s.amount / CORE_SYMBOL_PRECISION;
             }
 
             inline void add_total_staked( const uint32_t curr_block_num, const int64_t sa ) {
                total_voteage += total_staked * ( curr_block_num - voteage_update_height );
                voteage_update_height = curr_block_num;
                // JUST CORE_TOKEN can vote to bp
-               total_staked += sa / eosforce::utils::precision(CORE_SYMBOL.precision());
+               total_staked += sa / CORE_SYMBOL_PRECISION;
             }
 
             inline constexpr int64_t get_age( const uint32_t curr_block_num ) const {

--- a/contracts/eosio.system/src/vote.cpp
+++ b/contracts/eosio.system/src/vote.cpp
@@ -45,15 +45,11 @@ namespace eosio {
       }
 
       bps_tbl.modify( bpf, name{0}, [&]( bp_info& b ) {
-         b.total_voteage += b.total_staked * ( curr_block_num - b.voteage_update_height );
-         b.voteage_update_height = curr_block_num;
-         b.total_staked -= restake.amount / 10000;
+         b.add_total_staked( curr_block_num, -restake );
       } );
 
       bps_tbl.modify( bpt, name{0}, [&]( bp_info& b ) {
-         b.total_voteage += b.total_staked * ( curr_block_num - b.voteage_update_height );
-         b.voteage_update_height = curr_block_num;
-         b.total_staked += restake.amount / 10000;
+         b.add_total_staked( curr_block_num, restake );
       } );
    }
 
@@ -113,9 +109,7 @@ namespace eosio {
       }
 
       bps_tbl.modify( bp, name{0}, [&]( bp_info& b ) {
-         b.total_voteage += b.total_staked * ( curr_block_num - b.voteage_update_height );
-         b.voteage_update_height = curr_block_num;
-         b.total_staked += ( change / 10000 );
+         b.add_total_staked( curr_block_num, change );
       } );
    }
 
@@ -195,9 +189,7 @@ namespace eosio {
       }
 
       bps_tbl.modify( bp, name{0}, [&]( bp_info& b ) {
-         b.total_voteage += b.total_staked * ( curr_block_num - b.voteage_update_height );
-         b.voteage_update_height = curr_block_num;
-         b.total_staked += change / 10000;
+         b.add_total_staked( curr_block_num, change );
       } );
 
       vote4ramsum_table vote4ramsum_tbl( _self, _self.value );
@@ -252,7 +244,7 @@ namespace eosio {
       const auto& vts = votes_tbl.get( bpname, "voter have not add votes to the the producer yet" );
 
       const int64_t newest_voteage = vts.voteage.get_age( curr_block_num );
-      const int64_t newest_total_voteage = bp.total_voteage + bp.total_staked * ( curr_block_num - bp.voteage_update_height );
+      const int64_t newest_total_voteage = bp.get_age( curr_block_num );
       check( 0 < newest_total_voteage, "claim is not available yet" );
 
       int128_t amount_voteage = (int128_t)bp.rewards_pool.amount * (int128_t)newest_voteage;

--- a/contracts/eosio.system/src/vote.cpp
+++ b/contracts/eosio.system/src/vote.cpp
@@ -13,7 +13,7 @@ namespace eosio {
       require_auth( name{voter} );
       check( frombp != tobp, " from and to cannot same" );
       check( restake.symbol == CORE_SYMBOL, "only support EOS which has 4 precision" );
-      check( restake.amount > 0 && ( restake.amount % 10000 == 0 ),
+      check( restake.amount > 0 && ( restake.amount % CORE_SYMBOL_PRECISION == 0 ),
             "need restake quantity > 0.0000 EOS and quantity is integer" );
 
       bps_table bps_tbl( _self, _self.value );
@@ -64,7 +64,7 @@ namespace eosio {
       const auto& bp = bps_tbl.get( bpname, "bpname is not registered" );
 
       check( stake.symbol == CORE_SYMBOL, "only support EOS which has 4 precision" );
-      check( 0 <= stake.amount && stake.amount % 10000 == 0,
+      check( 0 <= stake.amount && stake.amount % CORE_SYMBOL_PRECISION == 0,
              "need stake quantity >= 0.0000 EOS and quantity is integer" );
 
       const auto curr_block_num = current_block_num();
@@ -145,7 +145,7 @@ namespace eosio {
       const auto& bp = bps_tbl.get( bpname, "bpname is not registered" );
 
       check( stake.symbol == CORE_SYMBOL, "only support EOS which has 4 precision" );
-      check( 0 <= stake.amount && stake.amount % 10000 == 0,
+      check( 0 <= stake.amount && stake.amount % CORE_SYMBOL_PRECISION == 0,
             "need stake quantity >= 0.0000 EOS and quantity is integer" );
 
       const auto curr_block_num = current_block_num();

--- a/contracts/include/eosforce/assetage.hpp
+++ b/contracts/include/eosforce/assetage.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <eosio/eosio.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/crypto.hpp>
+
+namespace eosforce {
+
+
+
+   namespace utils{
+      constexpr inline int64_t precision( const uint8_t decimals ) {
+         constexpr uint8_t res_size = 18;
+         constexpr int64_t res[res_size] = 
+            {  1, 10, 100, 1000, 10000, 
+               100000, 
+               1000000, 
+               10000000,
+               100000000,
+               1000000000,
+               10000000000,
+               100000000000,
+               1000000000000,
+               10000000000000,
+               100000000000000,
+               1000000000000000,
+               10000000000000000,
+               100000000000000000 };
+
+         if( decimals < res_size ) {
+            return res[decimals];
+         } else {
+            auto p10 = res[res_size - 1];
+            for( auto p = static_cast<int64_t>(decimals - res_size + 1); 
+               p > 0; --p ) {
+               p10 *= 10;
+            }
+            return p10;
+         }
+      }
+   }
+
+   using eosio::symbol;
+   using eosio::symbol_code;
+   using eosio::asset;
+
+   // asset age : asset age is a value equal asset * age by block num, in eosforce
+   //             it used in many pos.
+   struct assetage {
+      constexpr int64_t get_age( const uint32_t block_num ) const {
+         return ((staked.amount / utils::precision(staked.symbol.precision())) * ( block_num - update_height )) + age;
+      }
+
+
+      asset     staked;
+      uint32_t  update_height = 0;
+      int64_t   age           = 0;
+
+      EOSLIB_SERIALIZE( assetage, (staked)(update_height)(age) )
+   };
+
+} // namespace eosforce

--- a/contracts/include/eosforce/assetage.hpp
+++ b/contracts/include/eosforce/assetage.hpp
@@ -6,7 +6,7 @@
 
 namespace eosforce {
    namespace utils{
-      constexpr inline int64_t precision( const uint8_t decimals ) {
+      constexpr inline int64_t precision_base( const uint8_t decimals ) {
          constexpr uint8_t res_size = 18;
          constexpr int64_t res[res_size] = 
             {  1, 10, 100, 1000, 10000, 
@@ -38,7 +38,7 @@ namespace eosforce {
    }
 
    constexpr auto CORE_SYMBOL = eosio::symbol(eosio::symbol_code("EOS"), 4);
-   constexpr auto CORE_SYMBOL_PRECISION = utils::precision(CORE_SYMBOL.precision());
+   constexpr auto CORE_SYMBOL_PRECISION = utils::precision_base(CORE_SYMBOL.precision());
 
    using eosio::symbol;
    using eosio::symbol_code;
@@ -48,7 +48,7 @@ namespace eosforce {
    //             it used in many pos.
    struct assetage {
       inline constexpr int64_t get_age( const uint32_t curr_block_num ) const {
-         return ((staked.amount / utils::precision(staked.symbol.precision())) * ( curr_block_num - update_height )) + age;
+         return ((staked.amount / utils::precision_base(staked.symbol.precision())) * ( curr_block_num - update_height )) + age;
       }
 
       inline void change_staked_to( const uint32_t curr_block_num, const asset& new_staked ) {

--- a/contracts/include/eosforce/assetage.hpp
+++ b/contracts/include/eosforce/assetage.hpp
@@ -75,10 +75,10 @@ namespace eosforce {
       }
 
       asset     staked        = asset{ 0, CORE_SYMBOL };
-      uint32_t  update_height = 0;
       int64_t   age           = 0;
+      uint32_t  update_height = 0;
 
-      EOSLIB_SERIALIZE( assetage, (staked)(update_height)(age) )
+      EOSLIB_SERIALIZE( assetage, (staked)(age)(update_height) )
    };
 
 } // namespace eosforce

--- a/contracts/include/eosforce/assetage.hpp
+++ b/contracts/include/eosforce/assetage.hpp
@@ -52,7 +52,7 @@ namespace eosforce {
       }
 
 
-      asset     staked;
+      asset     staked        = asset{ 0, CORE_SYMBOL };
       uint32_t  update_height = 0;
       int64_t   age           = 0;
 

--- a/contracts/include/eosforce/assetage.hpp
+++ b/contracts/include/eosforce/assetage.hpp
@@ -6,7 +6,7 @@
 
 namespace eosforce {
 
-
+   constexpr auto CORE_SYMBOL = eosio::symbol(eosio::symbol_code("EOS"), 4);
 
    namespace utils{
       constexpr inline int64_t precision( const uint8_t decimals ) {

--- a/contracts/include/eosforce/assetage.hpp
+++ b/contracts/include/eosforce/assetage.hpp
@@ -47,10 +47,32 @@ namespace eosforce {
    // asset age : asset age is a value equal asset * age by block num, in eosforce
    //             it used in many pos.
    struct assetage {
-      constexpr int64_t get_age( const uint32_t block_num ) const {
-         return ((staked.amount / utils::precision(staked.symbol.precision())) * ( block_num - update_height )) + age;
+      inline constexpr int64_t get_age( const uint32_t curr_block_num ) const {
+         return ((staked.amount / utils::precision(staked.symbol.precision())) * ( curr_block_num - update_height )) + age;
       }
 
+      inline void change_staked_to( const uint32_t curr_block_num, const asset& new_staked ) {
+         age = get_age( curr_block_num );
+         update_height = curr_block_num;
+         staked = new_staked;
+      }
+
+      inline void add_staked_by( const uint32_t curr_block_num, const asset& s ) {
+         age = get_age( curr_block_num );
+         update_height = curr_block_num;
+         staked += s;
+      }
+
+      inline void minus_staked_by( const uint32_t curr_block_num, const asset& s ) {
+         age = get_age( curr_block_num );
+         update_height = curr_block_num;
+         staked -= s;
+      }
+
+      inline void clean_age( const uint32_t curr_block_num ) {
+         age = 0;
+         update_height = curr_block_num;
+      }
 
       asset     staked        = asset{ 0, CORE_SYMBOL };
       uint32_t  update_height = 0;

--- a/contracts/include/eosforce/assetage.hpp
+++ b/contracts/include/eosforce/assetage.hpp
@@ -5,9 +5,6 @@
 #include <eosio/crypto.hpp>
 
 namespace eosforce {
-
-   constexpr auto CORE_SYMBOL = eosio::symbol(eosio::symbol_code("EOS"), 4);
-
    namespace utils{
       constexpr inline int64_t precision( const uint8_t decimals ) {
          constexpr uint8_t res_size = 18;
@@ -39,6 +36,9 @@ namespace eosforce {
          }
       }
    }
+
+   constexpr auto CORE_SYMBOL = eosio::symbol(eosio::symbol_code("EOS"), 4);
+   constexpr auto CORE_SYMBOL_PRECISION = utils::precision(CORE_SYMBOL.precision());
 
    using eosio::symbol;
    using eosio::symbol_code;


### PR DESCRIPTION
Now in eosforce, there are many xxx ages consisting of a asset and a block heights, which requires a unified structure to represent.

This commit changes the abi of the vote_info table, which is binary compatible, but bp info is not in a compatible structure, so it only uses some func