### PR TITLE
Fix-Time Vote

### DIFF
--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -251,6 +251,9 @@ namespace eosio {
    using setemergency_action = eosio::action_wrapper<"setemergency"_n, &system_contract::setemergency>;
    using heartbeat_action    = eosio::action_wrapper<"heartbeat"_n,    &system_contract::heartbeat>;
    using removebp_action     = eosio::action_wrapper<"removebp"_n,     &system_contract::removebp>;
+   using votefix_action      = eosio::action_wrapper<"votefix"_n,      &system_contract::votefix>;
+   using revotefix_action    = eosio::action_wrapper<"revotefix"_n,    &system_contract::revotefix>;
+   using outfixvote_action   = eosio::action_wrapper<"outfixvote"_n,   &system_contract::outfixvote>;
 
    // for bp_info, cannot change it table struct
    inline void bp_info::add_total_staked( const uint32_t curr_block_num, const asset& s ) {

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -207,6 +207,21 @@ namespace eosio {
 
          [[eosio::action]] void unfreezeram( const account_name& voter, const account_name& bpname );
 
+         // make a fix-time vote by voter to bpname with stake token
+         // type is fix-time type, 
+         [[eosio::action]] void votefix( const account_name& voter,
+                                         const account_name& bpname,
+                                         const name& type,
+                                         const asset& stake );
+
+         [[eosio::action]] void revotefix( const account_name& voter,
+                                           const uint64_t& key,
+                                           const account_name& bpname );
+
+         // take out stake to a fix-time vote by voter after vote is timeout
+         [[eosio::action]] void outfixvote( const account_name& voter,
+                                            const uint64_t& key );
+
          [[eosio::action]] void claim( const account_name& voter, const account_name& bpname );
 
          [[eosio::action]] void onblock( const block_timestamp& timestamp,

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -8,7 +8,9 @@
 #include <string>
 
 #include <eosforce/assetage.hpp>
+
 #include <native.hpp>
+#include <vote.hpp>
 
 namespace eosio {
 
@@ -129,6 +131,7 @@ namespace eosio {
    typedef eosio::multi_index<"heartbeat"_n,   heartbeat_info>        hb_table;
    typedef eosio::multi_index<"blackpro"_n,    producer_blacklist>    blackproducer_table;
    typedef eosio::multi_index<"gvotestat"_n,   global_votestate_info> global_votestate_table;
+   typedef eosio::multi_index<"fixvotes"_n,    fix_time_votes>        fix_time_votes_table;
 
    /**
     * @defgroup system_contract eosio.system

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -131,7 +131,6 @@ namespace eosio {
    typedef eosio::multi_index<"heartbeat"_n,   heartbeat_info>        hb_table;
    typedef eosio::multi_index<"blackpro"_n,    producer_blacklist>    blackproducer_table;
    typedef eosio::multi_index<"gvotestat"_n,   global_votestate_info> global_votestate_table;
-   typedef eosio::multi_index<"fixvotes"_n,    fix_time_votes>        fix_time_votes_table;
 
    /**
     * @defgroup system_contract eosio.system

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -20,13 +20,13 @@ namespace eosio {
    using eosforce::CORE_SYMBOL;
    using eosforce::CORE_SYMBOL_PRECISION;
 
-   static constexpr uint32_t BLOCK_NUM_PER_DAY = 24 * 60 * 20;
-   static constexpr uint32_t FROZEN_DELAY      = 3 * BLOCK_NUM_PER_DAY;
-   static constexpr int NUM_OF_TOP_BPS         = 23;
-   static constexpr int BLOCK_REWARDS_BP       = 27000;
-   static constexpr int BLOCK_REWARDS_B1       = 3000;
-   static constexpr uint32_t UPDATE_CYCLE      = NUM_OF_TOP_BPS * 5; // every num blocks update
-   static constexpr uint32_t REWARD_B1_CYCLE   = NUM_OF_TOP_BPS * 100;
+   static constexpr uint32_t BLOCK_NUM_PER_DAY     = 24 * 60 * 20;
+   static constexpr uint32_t FROZEN_DELAY          = 3 * BLOCK_NUM_PER_DAY;
+   static constexpr int NUM_OF_TOP_BPS             = 23;
+   static constexpr int BLOCK_REWARDS_BP           = 27000;
+   static constexpr int BLOCK_REWARDS_B1           = 3000;
+   static constexpr uint32_t UPDATE_CYCLE          = NUM_OF_TOP_BPS * 5;     // every num blocks update
+   static constexpr uint32_t REWARD_B1_CYCLE       = NUM_OF_TOP_BPS * 100;
 
    static constexpr name eosforce_vote_stat = "eosforce"_n;
    static constexpr name chainstatus_name   = "chainstatus"_n;

--- a/contracts/eosio.system/include/vote.hpp
+++ b/contracts/eosio.system/include/vote.hpp
@@ -35,31 +35,28 @@ namespace eosio {
 
 
    // fix_time_votes : fix time vote infos for a account
-   struct [[eosio::table, eosio::contract("eosio.system")]] fix_time_votes {
-
-      // one fix time vote
-      struct fix_time_vote_info {
-         enum state {
-            nil = 0,
-            voting,
-            wait_withdraw,
-            wait_claim, wait_unfreeze,
-            unfreezed
-         };
-
-         name     fvote_typ          = name{ 0 };
-         assetage votepower_age;
-         asset    vote               = asset{ 0, CORE_SYMBOL };
-         uint32_t start_block_num    = 0;
-         uint32_t withdraw_block_num = 0;
-         bool     is_withdraw        = false;
-
-         // TODO: need use vote type by fvote_typ
-         inline state get_state( const uint32_t curr_block_num ) const { return state::nil; }
+   struct [[eosio::table, eosio::contract("eosio.system")]] fix_time_vote_info {
+      enum state {
+         nil = 0,
+         voting,
+         wait_withdraw,
+         wait_claim, wait_unfreeze,
+         unfreezed
       };
 
-      account_name                    voter = 0;
-      std::vector<fix_time_vote_info> votes;
-   };
+      uint64_t     key                = 0; // add by available_primary_key()
+      account_name voter              = 0;
+      name         fvote_typ          = name{ 0 };
+      assetage     votepower_age;
+      asset        vote               = asset{ 0, CORE_SYMBOL };
+      uint32_t     start_block_num    = 0;
+      uint32_t     withdraw_block_num = 0;
+      bool         is_withdraw        = false;
 
+      uint64_t primary_key() const { return key; }
+
+      // TODO: need use vote type by fvote_typ
+      inline state get_state( const uint32_t curr_block_num ) const { return state::nil; }
+   };
+   typedef eosio::multi_index<"fixvotes"_n, fix_time_vote_info> fix_time_votes_table;
 } // namespace eosio

--- a/contracts/eosio.system/include/vote.hpp
+++ b/contracts/eosio.system/include/vote.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <eosio/eosio.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/system.hpp>
+
+#include <string>
+
+#include <eosforce/assetage.hpp>
+
+namespace eosio {
+   using eosforce::assetage;
+   using eosforce::CORE_SYMBOL;
+   using eosforce::CORE_SYMBOL_PRECISION;
+
+   /**
+    *  From EOSForce FIP#7, There is two type vote : current voting and fix-time voting
+    *  
+    *  - Current voting: There is no fixed period for users to participate in voting.
+    *  - Fix-time voting: Users choose to vote in different voting time periods.
+    * 
+    *  For Different voting, the power of per stake token is different
+    */
+
+   /*
+      A fix-time vote state:
+
+        `start` -- fix-time vote --> `voting` -- curr block num after (start_bnum + fix_bnum) --> `wait withdraw( no reward )`   -------
+                                                                                                                                       |
+         `wait unfreeze` <-- user claim --  `wait claim ( no reward and no vote power )`  <-- user withdraw (set withdraw_block_num) --
+                |
+                ------ curr block num after withdraw_block_num + unfreeze_num --->  `unfreezed` -- user unfreeze --> `end ( data deleted )`
+   */
+
+
+   // fix_time_votes : fix time vote infos for a account
+   struct [[eosio::table, eosio::contract("eosio.system")]] fix_time_votes {
+
+      // one fix time vote
+      struct fix_time_vote_info {
+         enum state {
+            nil = 0,
+            voting,
+            wait_withdraw,
+            wait_claim, wait_unfreeze,
+            unfreezed
+         };
+
+         name     fvote_typ          = name{ 0 };
+         assetage votepower_age;
+         asset    vote               = asset{ 0, CORE_SYMBOL };
+         uint32_t start_block_num    = 0;
+         uint32_t withdraw_block_num = 0;
+         bool     is_withdraw        = false;
+
+         // TODO: need use vote type by fvote_typ
+         inline state get_state( const uint32_t curr_block_num ) const { return state::nil; }
+      };
+
+      account_name                    voter = 0;
+      std::vector<fix_time_vote_info> votes;
+   };
+
+} // namespace eosio

--- a/contracts/eosio.system/include/vote.hpp
+++ b/contracts/eosio.system/include/vote.hpp
@@ -67,7 +67,6 @@ namespace eosio {
          return std::optional<fix_vote_data_t>();
       }
 
-
       uint64_t     key                = 0; // add by available_primary_key()
       account_name voter              = 0;
       account_name bpname             = 0;
@@ -79,9 +78,12 @@ namespace eosio {
       bool         is_withdraw        = false;
 
       uint64_t primary_key() const { return key; }
+      uint64_t by_bp()const        { return bpname; }
 
       // TODO: need use vote type by fvote_typ
       inline state get_state( const uint32_t curr_block_num ) const { return state::nil; }
    };
-   typedef eosio::multi_index<"fixvotes"_n, fix_time_vote_info> fix_time_votes_table;
+   typedef eosio::multi_index< "fixvotes"_n, fix_time_vote_info, 
+                               indexed_by<"bybp"_n, const_mem_fun<fix_time_vote_info, uint64_t, &fix_time_vote_info::by_bp>>
+                             > fix_time_votes_table;
 } // namespace eosio

--- a/contracts/eosio.system/include/vote.hpp
+++ b/contracts/eosio.system/include/vote.hpp
@@ -70,6 +70,7 @@ namespace eosio {
 
       uint64_t     key                = 0; // add by available_primary_key()
       account_name voter              = 0;
+      account_name bpname             = 0;
       name         fvote_typ          = name{ 0 };
       assetage     votepower_age;
       asset        vote               = asset{ 0, CORE_SYMBOL };

--- a/contracts/eosio.system/include/vote.hpp
+++ b/contracts/eosio.system/include/vote.hpp
@@ -14,6 +14,9 @@ namespace eosio {
    using eosforce::CORE_SYMBOL;
    using eosforce::CORE_SYMBOL_PRECISION;
 
+   static constexpr uint64_t FIX_TIME_VOTE_POWER_M = 5;  // now vote power will be 0.2, so fix-time vote power will * 5
+
+
    /**
     *  From EOSForce FIP#7, There is two type vote : current voting and fix-time voting
     *  
@@ -43,6 +46,27 @@ namespace eosio {
          wait_claim, wait_unfreeze,
          unfreezed
       };
+
+      // fix vote type, NOTE Just Can Add New TYPE, NO CHANGE LAST!!!!!
+      // only can change fix-time num
+      using fix_vote_data_t = std::tuple<name, uint32_t, uint64_t>;
+      constexpr static auto fix_vote_typ_data = std::array<fix_vote_data_t, 4>{{
+         { "fvote.a"_n,   3 * 30,   1 * FIX_TIME_VOTE_POWER_M }, 
+         { "fvote.b"_n,   6 * 30,   2 * FIX_TIME_VOTE_POWER_M }, 
+         { "fvote.c"_n,  12 * 30,   4 * FIX_TIME_VOTE_POWER_M }, 
+         { "fvote.d"_n,  24 * 30,   8 * FIX_TIME_VOTE_POWER_M }
+      }};
+      // fix-time type not too much ( <= 8 ), so just find by for each
+      inline static std::optional<fix_vote_data_t> get_data_by_typ( const name& typ ) {
+         for( const auto& i : fix_vote_typ_data ) {
+            if( std::get<0>(i) == typ ) {
+               return i;
+            }
+         }
+
+         return std::optional<fix_vote_data_t>();
+      }
+
 
       uint64_t     key                = 0; // add by available_primary_key()
       account_name voter              = 0;

--- a/contracts/eosio.system/include/vote.hpp
+++ b/contracts/eosio.system/include/vote.hpp
@@ -81,7 +81,25 @@ namespace eosio {
       uint64_t by_bp()const        { return bpname; }
 
       // TODO: need use vote type by fvote_typ
-      inline state get_state( const uint32_t curr_block_num ) const { return state::nil; }
+      inline state get_state( const uint32_t& curr_block_num ) const { return state::nil; }
+
+      inline int64_t get_age( const uint32_t& curr_block_num ) const { 
+         // if fix-time vote has been withdraw_block_num, no reward to it
+         auto calc_block_num = curr_block_num;
+         if( calc_block_num > withdraw_block_num ) {
+            calc_block_num = withdraw_block_num;
+         }
+         return votepower_age.get_age( calc_block_num );
+      }
+
+      inline void clean_age( const uint32_t& curr_block_num ) {
+         // if fix-time vote has been withdraw_block_num, no reward to it
+         auto calc_block_num = curr_block_num;
+         if( calc_block_num > withdraw_block_num ) {
+            calc_block_num = withdraw_block_num;
+         }
+         votepower_age.clean_age( calc_block_num );
+      }
    };
    typedef eosio::multi_index< "fixvotes"_n, fix_time_vote_info, 
                                indexed_by<"bybp"_n, const_mem_fun<fix_time_vote_info, uint64_t, &fix_time_vote_info::by_bp>>

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -274,3 +274,27 @@ spec_version: "0.2.0"
 title: On Error
 summary: 'on error'
 ---
+
+<h1 class="contract">votefix</h1>
+
+---
+spec_version: "0.2.0"
+title: Fix Time Vote
+summary: '{{nowrap voter}} vote {{nowrap bpname}} by fix-time in {{nowrap type}} way with {{nowrap stake}} token'
+---
+
+<h1 class="contract">revotefix</h1>
+
+---
+spec_version: "0.2.0"
+title: Fix Time Revote
+summary: '{{nowrap voter}} revote {{nowrap key}} fix-time voting to {{nowrap bpname}}'
+---
+
+<h1 class="contract">outfixvote</h1>
+
+---
+spec_version: "0.2.0"
+title: Take out Fix Time Vote
+summary: 'When {{nowrap voter}} fix-time voting is timeout, {{nowrap voter}} can take out stake form {{nowrap key}} voting'
+---

--- a/contracts/eosio.system/src/vote.cpp
+++ b/contracts/eosio.system/src/vote.cpp
@@ -31,6 +31,7 @@ namespace eosio {
          votes_tbl.emplace( name{voter}, [&]( vote_info& v ) {
             v.bpname = bpname;
             v.voteage.staked = stake;
+            v.voteage.update_height = curr_block_num;
          } );
       } else {
          change = stake.amount - vts->voteage.staked.amount;
@@ -100,6 +101,7 @@ namespace eosio {
          votes_tbl.emplace( name{voter}, [&]( vote_info& v ) {
             v.bpname = tobp;
             v.voteage.staked = restake;
+            v.voteage.update_height = curr_block_num;
          } );
       } else {
          votes_tbl.modify( vtst, name{0}, [&]( vote_info& v ) {
@@ -252,14 +254,15 @@ namespace eosio {
       // Add fix vote data
       fix_time_votes_table fix_time_votes_tbl( get_self(), voter );
       fix_time_votes_tbl.emplace( name{voter}, [&]( fix_time_vote_info& fvi ) { 
-         fvi.key                  = fix_time_votes_tbl.available_primary_key();
-         fvi.voter                = voter;
-         fvi.bpname               = bpname;
-         fvi.fvote_typ            = type;
-         fvi.start_block_num      = curr_block_num;
-         fvi.withdraw_block_num   = curr_block_num + freeze_block_num;
-         fvi.vote                 = stake;
-         fvi.votepower_age.staked = vote_stake_by_power;
+         fvi.key                         = fix_time_votes_tbl.available_primary_key();
+         fvi.voter                       = voter;
+         fvi.bpname                      = bpname;
+         fvi.fvote_typ                   = type;
+         fvi.start_block_num             = curr_block_num;
+         fvi.withdraw_block_num          = curr_block_num + freeze_block_num;
+         fvi.vote                        = stake;
+         fvi.votepower_age.staked        = vote_stake_by_power;
+         fvi.votepower_age.update_height = curr_block_num;
       } );
 
       // modify account token

--- a/contracts/eosio.system/src/vote.cpp
+++ b/contracts/eosio.system/src/vote.cpp
@@ -213,4 +213,27 @@ namespace eosio {
       } );
    }
 
+   // make a fix-time vote by voter to bpname with stake token
+   // type is fix-time type, 
+   void system_contract::votefix( const account_name& voter,
+                                  const account_name& bpname,
+                                  const name& type,
+                                  const asset& stake ) {
+      require_auth( name{voter} );
+   }
+
+   void system_contract::revotefix( const account_name& voter,
+                                    const uint64_t& key,
+                                    const account_name& bpname ) {
+      require_auth( name{voter} );
+   }
+
+   // take out stake to a fix-time vote by voter after vote is timeout
+   void system_contract::outfixvote( const account_name& voter,
+                                     const uint64_t& key ) {
+      require_auth( name{voter} );
+   }
+
+
+
 } // namespace eosio

--- a/contracts/eosio.system/src/vote.cpp
+++ b/contracts/eosio.system/src/vote.cpp
@@ -183,19 +183,22 @@ namespace eosio {
       const auto curr_block_num = current_block_num();
 
       const auto& act = _accounts.get( voter, "voter is not found in accounts table" );
-
       const auto& bp = _bps.get( bpname, "bpname is not registered" );
 
-      votes_table votes_tbl( _self, voter );
+      votes_table votes_tbl( get_self(), voter );
       const auto& vts = votes_tbl.get( bpname, "voter have not add votes to the the producer yet" );
 
-      const int64_t newest_voteage = vts.voteage.get_age( curr_block_num );
-      const int64_t newest_total_voteage = bp.get_age( curr_block_num );
+      const auto newest_voteage = vts.voteage.get_age( curr_block_num );
+      const auto newest_total_voteage = bp.get_age( curr_block_num );
       check( 0 < newest_total_voteage, "claim is not available yet" );
 
-      int128_t amount_voteage = (int128_t)bp.rewards_pool.amount * (int128_t)newest_voteage;
-      const auto& reward = asset( static_cast<int64_t>( (int128_t)amount_voteage / (int128_t)newest_total_voteage ),CORE_SYMBOL );
-      check( 0 <= reward.amount && reward.amount <= bp.rewards_pool.amount,
+      const auto amount_voteage = 
+           static_cast<int128_t>(bp.rewards_pool.amount) 
+         * static_cast<int128_t>(newest_voteage);
+      const auto& reward = asset{
+         static_cast<int64_t>( amount_voteage / static_cast<int128_t>(newest_total_voteage) ), 
+         CORE_SYMBOL };
+      check( asset{0, CORE_SYMBOL} <= reward && reward <= bp.rewards_pool,
             "need 0 <= claim reward quantity <= rewards_pool" );
 
       _accounts.modify( act, name{0}, [&]( account_info& a ) { 


### PR DESCRIPTION
In eosforce FIP #7,  there is a new vote type by fix time staking,
there is imp to new fix-time voting.

New actions to system contract:

- votefix : account create a fix-time vote to a bp
- revotefix : account change bp voted to from a fix-time vote, no change vote stat
- outfixvote : when fix-time vote timeout, account should take out it

Also change some vote code.