### PR TITLE
Fix-time Vote Support Different Stake Type

### DIFF
--- a/contracts/eosio.system/README_zh.md
+++ b/contracts/eosio.system/README_zh.md
@@ -249,6 +249,13 @@ warning: transaction executed locally, but may not be confirmed by the network y
 因为涉及到投票奖励, 所以当用户解除定期投票之后, 投票的信息并不会被删去, 系统只是简单的设置一个flag, 标示该定期投票已失效,
 在用户领取完投票奖励之后, 该信息会被删去, 并返还用户RAM.
 
+定期投票可以基于用户的Token, 也可以基于用户当前待赎回中的Token, 这个根据`stake_typ`的不同而不同.
+
+stake_typ 参数如下:
+
+- use_account_token 1 : 基于用户账户中的EOSC
+- use_unstaking_token 2 : 基于用户待赎回中的EOSC
+
 定期投票信息存储在`fixvotes`表中, 可以查询到:
 
 ```bash
@@ -315,7 +322,8 @@ warning: transaction executed locally, but may not be confirmed by the network y
          [[eosio::action]] void votefix( const account_name& voter,
                                          const account_name& bpname,
                                          const name& type,
-                                         const asset& stake );
+                                         const asset& stake,
+                                         const uint32_t& stake_typ );
 ```
 
 参数:
@@ -324,6 +332,7 @@ warning: transaction executed locally, but may not be confirmed by the network y
 - bpname : 所投节点
 - type : 定期投票类型
 - stake : 投票的核心代币数量
+- stake_typ : 为1时使用用户token投票, 为2时使用用户待赎回时的token投票
 
 最小权限:
 

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -51,6 +51,11 @@ namespace eosio {
       PUNISHED
    };
 
+   enum vote_stake_typ : uint32_t {
+      use_account_token   = 1,
+      use_unstaking_token = 2
+   };
+
    // tables
    struct [[eosio::table, eosio::contract("eosio.system")]] account_info {
       account_name name      = 0;
@@ -297,7 +302,8 @@ namespace eosio {
          [[eosio::action]] void votefix( const account_name& voter,
                                          const account_name& bpname,
                                          const name& type,
-                                         const asset& stake );
+                                         const asset& stake,
+                                         const uint32_t& stake_typ );
 
          [[eosio::action]] void revotefix( const account_name& voter,
                                            const uint64_t& key,

--- a/contracts/eosio.system/src/vote.cpp
+++ b/contracts/eosio.system/src/vote.cpp
@@ -244,7 +244,8 @@ namespace eosio {
    void system_contract::votefix( const account_name& voter,
                                   const account_name& bpname,
                                   const name& type,
-                                  const asset& stake ) {
+                                  const asset& stake,
+                                  const uint32_t& stake_typ ) {
       require_auth( name{voter} );
 
       // All fix-time voting is new

--- a/contracts/eosio.system/src/vote.cpp
+++ b/contracts/eosio.system/src/vote.cpp
@@ -264,7 +264,32 @@ namespace eosio {
       check( stake.symbol == CORE_SYMBOL, "only support CORE SYMBOL token" );
       check( 0 < stake.amount && stake.amount % 10000 == 0,
              "need stake quantity >= 0 and quantity is integer" );
-      check( stake <= act.available, "need stake quantity <= your available balance" );
+
+      switch ( stake_typ ) {
+         case vote_stake_typ::use_account_token:
+            {
+               check( stake <= act.available, "need stake quantity <= your available balance" );
+               // modify account token
+               _accounts.modify( act, name{0}, [&]( account_info& a ) { 
+                  a.available -= stake; 
+               } );
+            }
+            break;
+
+         case vote_stake_typ::use_unstaking_token:
+            {
+               votes_table votes_tbl( get_self(), voter );
+               const auto& vts = votes_tbl.get( bpname, "voter have not add votes to the the producer yet" );
+               check( stake < vts.unstaking, "need stake quantity <= your unstaking token" );
+               votes_tbl.modify( vts, name{0}, [&]( vote_info& v ) { 
+                  v.unstaking -= stake; 
+               } );
+            }
+            break;
+         
+         default:
+            check( false, "unsupport stake_typ!" );
+      }
 
       const auto curr_block_num = current_block_num();
 
@@ -285,11 +310,6 @@ namespace eosio {
          fvi.vote                        = stake;
          fvi.votepower_age.staked        = vote_stake_by_power;
          fvi.votepower_age.update_height = curr_block_num;
-      } );
-
-      // modify account token
-      _accounts.modify( act, name{0}, [&]( account_info& a ) { 
-         a.available -= stake; 
       } );
 
       _bps.modify( bp, name{0}, [&]( bp_info& b ) {


### PR DESCRIPTION
Now Fix-time vote JUST support vote by token in accounts, so if one account vote for a bp by current-type, it need unfreeze at first, then wait for three days, so it can make a fix-time vote.

In this commit votefix action add a param to show which type token to stake, so account not need wait to switch vote from current vote to fix-time vote.