### PR TITLE
rst.rweightl  system config add

### DIFF
--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -47,6 +47,7 @@ namespace eosio {
 
    static constexpr auto CONFIG_BLOCK_OUT_WEIGHT_LIMIT = "r.weightl"_n;
    static constexpr auto CONFIG_APPROVE_TO_PUNISH_NUM = "pun.appnum"_n;
+   static constexpr auto CONFIG_RESET_BLOCK_WEIGHT_NUM = "rst.rweightl"_n;
 
    static constexpr name eosforce_vote_stat = "eosforce"_n;
    static constexpr name chainstatus_name   = "chainstatus"_n;


### PR DESCRIPTION
Prevent the loss caused by the leakage block to the BP due to network jitter. How many blocks of BP are leaked by the rst.rweightl parameter will be reset to 1000.