### PR TITLE
add action to eosio.system(reqauth, setprods, activate, reqactivated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,10 @@
 *.app
 
 \.vscode/
+\.idea/
 build/
 buildc/
+cmake-build-debug/
 
 tools/push_freezeds/node_modules/
 

--- a/contracts/eosio.system/CMakeLists.txt
+++ b/contracts/eosio.system/CMakeLists.txt
@@ -6,7 +6,8 @@ add_contract(eosio.system eosio.system
    ${CMAKE_CURRENT_SOURCE_DIR}/src/native.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/vote.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/bppunish.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/src/freeze.cpp)
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/freeze.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/activate.cpp)
 
 target_include_directories(eosio.system PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../eosio.freeze/include)
 

--- a/contracts/eosio.system/include/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system.hpp
@@ -375,6 +375,11 @@ namespace eosio {
          [[eosio::action]] void monitorevise( const account_name& bpname );
          [[eosio::action]] void removepunish( const account_name& bpname );
          [[eosio::action]] void updateconfig( const name& config,const uint64_t &number_value,const string &string_value );
+
+         [[eosio::action]] void reqauth( name from );
+         [[eosio::action]] void setprods( std::vector<eosio::producer_key> schedule );
+         [[eosio::action]] void activate( const eosio::checksum256& feature_digest );
+         [[eosio::action]] void reqactivated( const eosio::checksum256& feature_digest );
    };
 
    using transfer_action     = eosio::action_wrapper<"transfer"_n,     &system_contract::transfer>;
@@ -396,6 +401,10 @@ namespace eosio {
    using bailpunish_action   = eosio::action_wrapper<"bailpunish"_n,   &system_contract::bailpunish>;
    using bpclaim_action      = eosio::action_wrapper<"bpclaim"_n,      &system_contract::bpclaim>;
    using removepunish_action = eosio::action_wrapper<"removepunish"_n, &system_contract::removepunish>;
+   using reqauth_action      = eosio::action_wrapper<"reqauth"_n,      &system_contract::reqauth>;
+   using setprods_action     = eosio::action_wrapper<"setprods"_n,     &system_contract::setprods>;
+   using activate_action     = eosio::action_wrapper<"activate"_n,     &system_contract::activate>;
+   using reqactivated_action = eosio::action_wrapper<"reqactivated"_n, &system_contract::reqactivated>;
 
    // for bp_info, cannot change it table struct
    inline void bp_info::add_total_staked( const uint32_t curr_block_num, const asset& s ) {

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -346,3 +346,35 @@ spec_version: "0.2.0"
 title: update system config on eosio.system
 summary: 'If there is systemconfig, use systemconfig to calculate, otherwise use the default value to calculate'
 ---
+
+<h1 class="contract">reqauth</h1>
+
+---
+spec_version: "0.2.0"
+title: Assert Authorization
+summary: 'Assert that authorization by {{nowrap from}} is provided'
+---
+
+<h1 class="contract">setprods</h1>
+
+---
+spec_version: "0.2.0"
+title: Set Block Producers
+summary: 'Set block producer schedule'
+---
+
+<h1 class="contract">activate</h1>
+
+---
+spec_version: "0.2.0"
+title: Activate Protocol Feature
+summary: 'Activate protocol feature {{nowrap feature_digest}}'
+---
+
+<h1 class="contract">reqactivated</h1>
+
+---
+spec_version: "0.2.0"
+title: Assert Protocol Feature Activation
+summary: 'Assert that protocol feature {{nowrap feature_digest}} has been activated'
+---

--- a/contracts/eosio.system/src/activate.cpp
+++ b/contracts/eosio.system/src/activate.cpp
@@ -1,0 +1,48 @@
+#include <utility>
+
+#include <eosio.system.hpp>
+
+#include <eosio/../../capi/eosio/crypto.h>
+
+namespace eosio {
+   namespace internal_use_do_not_use {
+      extern "C" {
+      __attribute__((eosio_wasm_import))
+      bool is_feature_activated( const ::capi_checksum256* feature_digest );
+
+      __attribute__((eosio_wasm_import))
+      void preactivate_feature( const ::capi_checksum256* feature_digest );
+      }
+   }
+}
+
+namespace eosio {
+   bool is_feature_activated(const eosio::checksum256 &feature_digest) {
+      auto feature_digest_data = feature_digest.extract_as_byte_array();
+      return internal_use_do_not_use::is_feature_activated(
+            reinterpret_cast<const ::capi_checksum256 *>( feature_digest_data.data())
+      );
+   }
+
+   void preactivate_feature(const eosio::checksum256 &feature_digest) {
+      auto feature_digest_data = feature_digest.extract_as_byte_array();
+      internal_use_do_not_use::preactivate_feature(
+            reinterpret_cast<const ::capi_checksum256 *>( feature_digest_data.data())
+      );
+   }
+}
+
+namespace eosio {
+
+   void system_contract::activate( const eosio::checksum256& feature_digest ) {
+      require_auth( get_self() );
+      preactivate_feature( feature_digest );
+   }
+
+   void system_contract::reqactivated( const eosio::checksum256& feature_digest ) {
+      check( is_feature_activated( feature_digest ), "protocol feature is not activated" );
+   }
+
+} /// namespace eosio
+
+

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -35,4 +35,8 @@ namespace eosio {
          });
       }
    }
+
+   void system_contract::reqauth( name from ) {
+      require_auth( from );
+   }
 } /// namespace eosio

--- a/contracts/eosio.system/src/producer.cpp
+++ b/contracts/eosio.system/src/producer.cpp
@@ -129,4 +129,9 @@ namespace eosio {
 
    }
 
+   void system_contract::setprods( std::vector<eosio::producer_key> schedule ) {
+      require_auth( get_self() );
+      set_proposed_producers( schedule );
+   }
+
 } // namespace eosio


### PR DESCRIPTION
添加eosforce系统合约缺失的方法支持unittest通过
添加方法：reqauth, setprods, activate, reqactivated
